### PR TITLE
Remove unnecessary init in AESGCMBench:setup

### DIFF
--- a/micros-jdk8/src/main/java/org/openjdk/bench/javax/crypto/full/AESGCMBench.java
+++ b/micros-jdk8/src/main/java/org/openjdk/bench/javax/crypto/full/AESGCMBench.java
@@ -84,8 +84,6 @@ public class AESGCMBench extends CryptoBase {
         encryptCipher.init(Cipher.ENCRYPT_MODE, ks, gcm_spec);
         encryptCipher.updateAAD(aad);
         decryptCipher = makeCipher(prov, algorithm);
-        decryptCipher.init(Cipher.DECRYPT_MODE, ks, encryptCipher.getParameters().getParameterSpec(GCMParameterSpec.class));
-        decryptCipher.updateAAD(aad);
         data = fillRandom(new byte[dataSize]);
         encryptedData = encryptCipher.doFinal(data);
     }


### PR DESCRIPTION
decryptCipher will be reinitialized in decrypt, which will loses all previously-acquired state. Therefore, it's not necessary to initialize in setup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh-jdk-microbenchmarks pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/jmh-jdk-microbenchmarks pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh-jdk-microbenchmarks/pull/8.diff">https://git.openjdk.java.net/jmh-jdk-microbenchmarks/pull/8.diff</a>

</details>
