### PR TITLE
Copy of base64 micros from openjdk main for jdk8 comparisons

### DIFF
--- a/micros-jdk8/src/main/java/org/openjdk/bench/java/util/Base64Decode.java
+++ b/micros-jdk8/src/main/java/org/openjdk/bench/java/util/Base64Decode.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.micro.bench.java.util;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Base64;
+import java.util.Random;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
+public class Base64Decode {
+
+    private Base64.Encoder encoder, mimeEncoder;
+    private Base64.Decoder decoder, mimeDecoder;
+    private ArrayList<byte[]> encoded, mimeEncoded, errorEncoded;
+    private byte[] decoded, mimeDecoded, errorDecoded;
+
+    private static final int TESTSIZE = 1000;
+
+    @Param({"1", "3", "7", "32", "64", "80", "96",
+            "112", "512", "1000", "20000", "50000"})
+    private int maxNumBytes;
+
+    @Param({"4"})
+    private int lineSize;
+
+    private byte[] lineSeparator = {'\r', '\n'};
+
+    /* Other value can be tested by passing parameters to the JMH
+       tests: -p errorIndex=3,64,144,208,272,1000,20000. */
+    @Param({"144"})
+    private int errorIndex;
+
+    @Setup
+    public void setup() {
+        Random r = new Random(1123);
+
+        decoded = new byte[maxNumBytes + 1];
+        encoder = Base64.getEncoder();
+        decoder = Base64.getDecoder();
+        encoded = new ArrayList<byte[]> ();
+
+        mimeDecoded = new byte[maxNumBytes + 1];
+        mimeEncoder = Base64.getMimeEncoder(lineSize, lineSeparator);
+        mimeDecoder = Base64.getMimeDecoder();
+        mimeEncoded = new ArrayList<byte[]> ();
+
+        errorDecoded = new byte[errorIndex + 100];
+        errorEncoded = new ArrayList<byte[]> ();
+
+        for (int i = 0; i < TESTSIZE; i++) {
+            int srcLen = 1 + r.nextInt(maxNumBytes);
+            byte[] src = new byte[srcLen];
+            byte[] dst = new byte[((srcLen + 2) / 3) * 4];
+            r.nextBytes(src);
+            encoder.encode(src, dst);
+            encoded.add(dst);
+
+            int mimeSrcLen = 1 + r.nextInt(maxNumBytes);
+            byte[] mimeSrc = new byte[mimeSrcLen];
+            byte[] mimeDst = new byte[((mimeSrcLen + 2) / 3) * 4 * (lineSize + lineSeparator.length) / lineSize];
+            r.nextBytes(mimeSrc);
+            mimeEncoder.encode(mimeSrc, mimeDst);
+            mimeEncoded.add(mimeDst);
+
+            int errorSrcLen = errorIndex + r.nextInt(100);
+            byte[] errorSrc = new byte[errorSrcLen];
+            byte[] errorDst = new byte[(errorSrcLen + 2) / 3 * 4];
+            r.nextBytes(errorSrc);
+            encoder.encode(errorSrc, errorDst);
+            errorEncoded.add(errorDst);
+            errorDst[errorIndex] = (byte) '?';
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(TESTSIZE)
+    public void testBase64Decode(Blackhole bh) {
+        for (byte[] s : encoded) {
+            decoder.decode(s, decoded);
+            bh.consume(decoded);
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(TESTSIZE)
+    public void testBase64MIMEDecode(Blackhole bh) {
+        for (byte[] s : mimeEncoded) {
+            mimeDecoder.decode(s, mimeDecoded);
+            bh.consume(mimeDecoded);
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(TESTSIZE)
+    public void testBase64WithErrorInputsDecode (Blackhole bh) {
+        for (byte[] s : errorEncoded) {
+            try {
+                 decoder.decode(s, errorDecoded);
+                 bh.consume(errorDecoded);
+            } catch (IllegalArgumentException e) {
+                 bh.consume(e);
+            }
+        }
+    }
+}

--- a/micros-jdk8/src/main/java/org/openjdk/bench/java/util/Base64Encode.java
+++ b/micros-jdk8/src/main/java/org/openjdk/bench/java/util/Base64Encode.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.micro.bench.java.util;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Base64;
+import java.util.Random;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
+public class Base64Encode {
+
+    private Base64.Encoder encoder;
+    private ArrayList<byte[]> unencoded;
+    private byte[] encoded;
+
+    private static final int TESTSIZE = 1000;
+
+    @Param({"1", "2", "3", "6", "7", "9", "10", "48", "512", "1000", "20000"})
+    private int maxNumBytes;
+
+    @Setup
+    public void setup() {
+        Random r = new Random(1123);
+
+        int dstLen = ((maxNumBytes + 16) / 3) * 4;
+
+        encoder = Base64.getEncoder();
+        unencoded = new ArrayList<byte[]> ();
+        encoded = new byte[dstLen];
+
+        for (int i = 0; i < TESTSIZE; i++) {
+            int srcLen = 1 + r.nextInt(maxNumBytes);
+            byte[] src = new byte[srcLen];
+            r.nextBytes(src);
+            unencoded.add(src);
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(TESTSIZE)
+    public void testBase64Encode(Blackhole bh) {
+        for (byte[] s : unencoded) {
+            encoder.encode(s, encoded);
+            bh.consume(encoded);
+        }
+    }
+}

--- a/micros-jdk8/src/main/java/org/openjdk/bench/java/util/Base64VarLenDecode.java
+++ b/micros-jdk8/src/main/java/org/openjdk/bench/java/util/Base64VarLenDecode.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2020, 2022, Oracle America, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of Oracle nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.openjdk.micro.bench.java.util;
+
+import org.openjdk.jmh.annotations.*;
+import java.util.*;
+
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 4, time = 2)
+@Fork(value = 3)
+public class Base64VarLenDecode {
+
+    @State(Scope.Thread)
+    public static class MyState {
+
+        @Setup(Level.Trial)
+        public void doSetupTrial() {
+            ran = new Random(10101); // fixed seed for repeatability
+            encoder = Base64.getEncoder();
+            decoder = Base64.getDecoder();
+        }
+
+        @Setup(Level.Invocation)
+        public void doSetupInvocation() {
+            bin_src_len = 8 + ran.nextInt(20000);
+            base64_len = ((bin_src_len + 2) / 3) * 4;
+            unencoded = new byte[bin_src_len];
+            encoded = new byte[base64_len];
+            decoded = new byte[bin_src_len];
+            ran.nextBytes(unencoded);
+            encoder.encode(unencoded, encoded);
+        }
+
+        @TearDown(Level.Invocation)
+        public void doTearDownInvocation() {
+            // This isn't really a teardown.  It's a check for correct functionality.
+            // Each iteration should produce a correctly decoded buffer that's equal
+            // to the unencoded data.
+            if (!Arrays.equals(unencoded, decoded)) {
+                System.out.println("Original data and decoded data are not equal!");
+                for (int j = 0; j < unencoded.length; j++) {
+                    if (unencoded[j] != decoded[j]) {
+                        System.out.format("%06x: %02x %02x\n", j, unencoded[j], decoded[j]);
+                    }
+                }
+                System.exit(1);
+            }
+        }
+
+        public Random ran;
+        public Base64.Encoder encoder;
+        public Base64.Decoder decoder;
+        public int bin_src_len;
+        public int base64_len;
+        public byte[] unencoded;
+        public byte[] encoded;
+        public byte[] decoded;
+    }
+
+    @Benchmark
+    public void decodeMethod(MyState state) {
+       state.decoder.decode(state.encoded, state.decoded);
+    }
+}


### PR DESCRIPTION
Include a few recently added Base64 micros to facilitate comparisons and tracking progress from JDK 8 and onwards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh-jdk-microbenchmarks pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/jmh-jdk-microbenchmarks pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh-jdk-microbenchmarks/pull/12.diff">https://git.openjdk.org/jmh-jdk-microbenchmarks/pull/12.diff</a>

</details>
