### PR TITLE
Update to jmh 1.36

### DIFF
--- a/micros-jdk11/pom.xml
+++ b/micros-jdk11/pom.xml
@@ -103,10 +103,6 @@
         </plugins>
     </build>
 
-    <properties>
-        <jmh.version>1.21</jmh.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.openjdk</groupId>

--- a/micros-jdk8/pom.xml
+++ b/micros-jdk8/pom.xml
@@ -126,10 +126,6 @@
         </plugins>
     </build>
 
-    <properties>
-        <jmh.version>1.21</jmh.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/micros-jdk9/pom.xml
+++ b/micros-jdk9/pom.xml
@@ -105,10 +105,6 @@
         </plugins>
     </build>
 
-    <properties>
-        <jmh.version>1.21</jmh.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jmh.version>1.21</jmh.version>
+        <jmh.version>1.36</jmh.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Time to upgrade the JMH. Among the other benefits I know that perfasm works better on aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh-jdk-microbenchmarks pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/jmh-jdk-microbenchmarks pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh-jdk-microbenchmarks/pull/13.diff">https://git.openjdk.org/jmh-jdk-microbenchmarks/pull/13.diff</a>

</details>
