### PR TITLE
Switch project to jdk to permit JDK reviewers, not code-tools reviewers.

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -22,7 +22,7 @@
 ;
 
 [general]
-project=code-tools
+project=jdk
 repository=jmh-jdk-microbenchmarks
 jbs=codetools
 


### PR DESCRIPTION
Based on an internal discussion, we decided that having JDK reviewers is more appropriate for this project.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Integration blocker
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh-jdk-microbenchmarks pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/jmh-jdk-microbenchmarks pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh-jdk-microbenchmarks/pull/14.diff">https://git.openjdk.org/jmh-jdk-microbenchmarks/pull/14.diff</a>

</details>
