### PR TITLE
7903893: The jmh-jdk-microbenchmarks/micros-javac is now bitrot with SecMgr removal

### DIFF
--- a/micros-javac/src/main/java/org/openjdk/bench/langtools/javac/JavacBenchmark.java
+++ b/micros-javac/src/main/java/org/openjdk/bench/langtools/javac/JavacBenchmark.java
@@ -94,7 +94,7 @@ public class JavacBenchmark {
             try (ZipInputStream zis = new ZipInputStream(new BufferedInputStream(JavacBenchmark.class.getResourceAsStream("/src.zip")))) {
                 for (ZipEntry entry; (entry = zis.getNextEntry()) != null;) {
                     final String ename = entry.getName();
-                    if (!ename.startsWith("java.desktop") && !ename.startsWith("jdk.internal.vm.compiler") && !ename.startsWith("jdk.aot")) {
+                    if (!ename.startsWith("java.desktop") && !ename.startsWith("jdk.internal.vm.compiler") && !ename.startsWith("jdk.aot") && !ename.startsWith("jdk.accessibility")) {
                         if (!entry.isDirectory() && ename.endsWith(".java")) {
                             Path dst = root.resolve(ename);
                             Files.createDirectories(dst.getParent());


### PR DESCRIPTION
It seems that problematic is jdk.accessibility module, so excluding it from the benchmark compilation.
Measured numbers may change after this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903893](https://bugs.openjdk.org/browse/CODETOOLS-7903893): The jmh-jdk-microbenchmarks/micros-javac is now bitrot with SecMgr removal (**Bug** - P4)


### Reviewers
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - Committer)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh-jdk-microbenchmarks.git pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/jmh-jdk-microbenchmarks.git pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh-jdk-microbenchmarks/pull/16.diff">https://git.openjdk.org/jmh-jdk-microbenchmarks/pull/16.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh-jdk-microbenchmarks/pull/16#issuecomment-2516697183)
</details>
