### PR TITLE
Exclusion of jdk.jsobject from javac benchmark due to Applet removal

### DIFF
--- a/micros-javac/src/main/java/org/openjdk/bench/langtools/javac/JavacBenchmark.java
+++ b/micros-javac/src/main/java/org/openjdk/bench/langtools/javac/JavacBenchmark.java
@@ -94,7 +94,7 @@ public class JavacBenchmark {
             try (ZipInputStream zis = new ZipInputStream(new BufferedInputStream(JavacBenchmark.class.getResourceAsStream("/src.zip")))) {
                 for (ZipEntry entry; (entry = zis.getNextEntry()) != null;) {
                     final String ename = entry.getName();
-                    if (!ename.startsWith("java.desktop") && !ename.startsWith("jdk.internal.vm.compiler") && !ename.startsWith("jdk.aot")) {
+                    if (!ename.startsWith("java.desktop") && !ename.startsWith("jdk.internal.vm.compiler") && !ename.startsWith("jdk.aot") && !ename.startsWith("jdk.jsobject") && !ename.startsWith("jdk.accessibility")) {
                         if (!entry.isDirectory() && ename.endsWith(".java")) {
                             Path dst = root.resolve(ename);
                             Files.createDirectories(dst.getParent());


### PR DESCRIPTION
Excluding jdk.jsobject from javac benchmarks due to compilation errors with the latest JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh-jdk-microbenchmarks.git pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/jmh-jdk-microbenchmarks.git pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh-jdk-microbenchmarks/pull/17.diff">https://git.openjdk.org/jmh-jdk-microbenchmarks/pull/17.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh-jdk-microbenchmarks/pull/17#issuecomment-3079428250)
</details>
